### PR TITLE
Scc 2591

### DIFF
--- a/event.json
+++ b/event.json
@@ -5,5 +5,6 @@
       "https"
     ]
   },
-  "multiValueQueryStringParameters": {}
+  "multiValueQueryStringParameters": {},
+  "host": ["catalog.nypl.org"]
 }

--- a/event2.json
+++ b/event2.json
@@ -5,5 +5,6 @@
       "https"
     ]
   },
-  "multiValueQueryStringParameters": {}
+  "multiValueQueryStringParameters": {},
+  "host": ["catalog.nypl.org"]
 }

--- a/event_search.json
+++ b/event_search.json
@@ -5,5 +5,6 @@
       "https"
     ]
   },
-  "multiValueQueryStringParameters": {}
+  "multiValueQueryStringParameters": {},
+  "host": ["catalog.nypl.org"]
 }

--- a/index.js
+++ b/index.js
@@ -74,19 +74,19 @@ const expressions = {
   },
 };
 
-function reconstructOriginalURL(path, query, host, method) {
+function reconstructOriginalURL(path, query, host, proto) {
   const reconstructedQuery = Object.entries(query).map(([key, values]) => {
       return values.map(value => value.length ? `${key}=${value}` : key).join('&')
     })
     .join('&');
-  return encodeURIComponent(`${method}://${host}${path}${reconstructedQuery.length ? '?' : ''}${reconstructedQuery}`);
+  return encodeURIComponent(`${proto}://${host}${path}${reconstructedQuery.length ? '?' : ''}${reconstructedQuery}`);
 }
 
 // The main method to build the redirectURL based on the incoming request
 // Given a path and a query, finds the first expression declared above which matches
 // the path, and returns the corresponding handler with the matchdata and query
 // As a default, returns the BASE_SCC_URL
-function mapWebPacUrlToSCCURL(path, query, host, method) {
+function mapWebPacUrlToSCCURL(path, query, host, proto) {
   let redirectURL;
   for (let pathType of Object.values(expressions)) {
       const match = path.match(pathType.expr);
@@ -105,10 +105,10 @@ const handler = async (event, context, callback) => {
     console.log('event: ', event);
     let path = event.path;
     let query = event.multiValueQueryStringParameters;
-    let method = event.multiValueHeaders['x-forwarded-proto'][0] ;
+    let proto = event.multiValueHeaders['x-forwarded-proto'][0] ;
     let host = event.host[0];
-    let mappedUrl = mapWebPacUrlToSCCURL(path, query, host, method);
-    let redirectLocation = `${method}://${mappedUrl}`;
+    let mappedUrl = mapWebPacUrlToSCCURL(path, query, host, proto);
+    let redirectLocation = `${proto}://${mappedUrl}`;
     const response = {
       isBase64Encoded: false,
       statusCode: 301,
@@ -120,9 +120,9 @@ const handler = async (event, context, callback) => {
   }
   catch(err) {
     console.log('err: ', err.message);
-    let method = event.multiValueHeaders['x-forwarded-proto'][0] ;
+    let proto = event.multiValueHeaders['x-forwarded-proto'][0] ;
     let mappedUrl = BASE_SCC_URL;
-    let redirectLocation = `${method}://${mappedUrl}`;
+    let redirectLocation = `${proto}://${mappedUrl}`;
     const response = {
       isBase64Encoded: false,
       statusCode: 301,

--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function mapWebPacUrlToSCCURL(path, query, host, proto) {
       }
   }
   if (!redirectURL) redirectURL = BASE_SCC_URL;
-  redirectURL = redirectURL + (redirectURL.includes('?') ? '&' : '?') + 'originalUrl=' + reconstructOriginalURL(path, query, host, method);
+  redirectURL = redirectURL + (redirectURL.includes('?') ? '&' : '?') + 'originalUrl=' + reconstructOriginalURL(path, query, host, proto);
   return redirectURL;
 }
 

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ const handler = async (event, context, callback) => {
   try {
     console.log('event: ', event);
     let path = event.path;
-    let query = event.multiValueQueryStringParameters;
+    let query = event.multiValueQueryStringParameters || {};
     let proto = event.multiValueHeaders['x-forwarded-proto'][0] ;
     let host = event.host[0];
     let mappedUrl = mapWebPacUrlToSCCURL(path, query, host, proto);

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function reconstructOriginalURL(path, query, host, method) {
 // Given a path and a query, finds the first expression declared above which matches
 // the path, and returns the corresponding handler with the matchdata and query
 // As a default, returns the BASE_SCC_URL
-function mapWebPacUrlToSCCURL(path, query) {
+function mapWebPacUrlToSCCURL(path, query, host, method) {
   let redirectURL;
   for (let pathType of Object.values(expressions)) {
       const match = path.match(pathType.expr);

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -3,38 +3,41 @@ const env = require('./test.js');
 const { mapWebPacUrlToSCCURL, handler, BASE_SCC_URL } = require('../../index.js');
 const axios = require('axios');
 
+const host = 'catalog.nypl.org';
+const method = 'https';
+
 describe('mapWebPacUrlToSCCURL', function() {
   it('should map the base URL correctly', function() {
     const path = '/';
     const query = {};
-    const mapped = mapWebPacUrlToSCCURL(path, query);
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
     expect(mapped)
-      .to.eql(BASE_SCC_URL)
+      .to.eql(BASE_SCC_URL + '?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2F')
   });
 
   it('should map bib pages correctly', function() {
     const path = '/record=b12172157~S1'
     axios.post = () => ({ data: { access_token: '' } });
     axios.get = () => ({ data: { uri: 'b12172157' } });
-    const mapped = mapWebPacUrlToSCCURL(path, {});
+    const mapped = mapWebPacUrlToSCCURL(path, {}, host, method);
     expect(mapped)
-      .to.eql(`${BASE_SCC_URL}/bib/b12172157`)
+      .to.eql(`${BASE_SCC_URL}/bib/b12172157?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db12172157~S1`)
   })
 
   it('should map search pages using the format /Xsearchterm', function() {
     const path = '/search~S1/aRubina%2C+Dina/arubina+dina/1%2C2%2C84%2CB/exact&FF=arubina+dina+author&1%2C-1%2C/indexsort=-)';
     const query = {};
-    const mapped = mapWebPacUrlToSCCURL(path, query);
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
     expect(mapped)
-      .to.eql(`${BASE_SCC_URL}/search?q=Rubina%2C%20Dina&search_scope=contributor`)
+      .to.eql(`${BASE_SCC_URL}/search?q=Rubina%2C%20Dina&search_scope=contributor&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S1%2FaRubina%252C%2BDina%2Farubina%2Bdina%2F1%252C2%252C84%252CB%2Fexact%26FF%3Darubina%2Bdina%2Bauthor%261%252C-1%252C%2Findexsort%3D-)`)
   });
 
   it('should map search pages with index but no search term', function() {
     const path = '/search/t';
     const query = {};
-    const mapped = mapWebPacUrlToSCCURL(path, query);
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
     expect(mapped)
-      .to.eql(`${BASE_SCC_URL}/search?q=&search_scope=title`)
+      .to.eql(`${BASE_SCC_URL}/search?q=&search_scope=title&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch%2Ft`)
   });
 
   it('should map search pages with searcharg and searchtype given as parameters', function() {
@@ -51,10 +54,10 @@ describe('mapWebPacUrlToSCCURL', function() {
       searchorigarg: ['dmystery'],
     };
 
-    const mapped = mapWebPacUrlToSCCURL(path, query);
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
 
     expect(mapped)
-      .to.eql(`${BASE_SCC_URL}/search?q=winspeare,%20j&search_scope=contributor`)
+      .to.eql(`${BASE_SCC_URL}/search?q=winspeare,%20j&search_scope=contributor&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S1%2F%3Fsearchtype%3Da%26searcharg%3Dwinspeare%2C%20j%26searchscope%3D1%26sortdropdown%3D-%26SORT%3DD%26extended%3D0%26SUBMIT%3DSearch%26searchlimits%26searchorigarg%3Ddmystery`)
   });
 
   it('should map search pages with SEARCH given as parameter', function() {
@@ -64,10 +67,10 @@ describe('mapWebPacUrlToSCCURL', function() {
       sortdropdown: ['-'],
       searchscope: ['1'],
     };
-    const mapped = mapWebPacUrlToSCCURL(path, query);
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
 
     expect(mapped)
-      .to.eql(`${BASE_SCC_URL}/search?q=The%20Mothers%20&search_scope=title`)
+      .to.eql(`${BASE_SCC_URL}/search?q=The%20Mothers%20&search_scope=title&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch%2Ft%3FSEARCH%3DThe%2BMothers%2B%26sortdropdown%3D-%26searchscope%3D1`)
   });
 
   it('should map search pages with search query given as query param', function() {
@@ -75,9 +78,9 @@ describe('mapWebPacUrlToSCCURL', function() {
     const query = {
       'jac+winspeare%2C': [''],
     };
-    const mapped = mapWebPacUrlToSCCURL(path, query);
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
     expect(mapped)
-      .to.eql(`${BASE_SCC_URL}/search?q=jac%20winspeare%2C&search_scope=contributor`)
+      .to.eql(`${BASE_SCC_URL}/search?q=jac%20winspeare%2C&search_scope=contributor&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S1%2Fa%3Fjac%2Bwinspeare%252C`)
   });
 
   it('should map search pages with search query and search type as query param', function() {
@@ -87,24 +90,24 @@ describe('mapWebPacUrlToSCCURL', function() {
       'FF': ['tbrainwash'],
       '1,4,': [''],
     };
-    const mapped = mapWebPacUrlToSCCURL(path, query);
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
     expect(mapped)
-      .to.eql(`${BASE_SCC_URL}/search?q=brainwash&search_scope=title`)
+      .to.eql(`${BASE_SCC_URL}/search?q=brainwash&search_scope=title&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S97%3F%2Ftbrainwash%2Ftbrainwash%2F1%2C3%2C10%2CB%2Fexact%26FF%3Dtbrainwash%261%2C4%2C`)
   });
 
   it('should return base url if no match is found', function() {
     const path = '/record=&%!^/';
     const query = {};
-    const mapped = mapWebPacUrlToSCCURL(path, query);
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
     expect(mapped)
-      .to.eql('https://discovery.nypl.org');
+      .to.eql('https://discovery.nypl.org?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3D%26%25!%5E%2F');
   });
 
   it('should return account page for research my account', () => {
     const path = '/patroninfo/1234567';
     const query = {};
-    const mapped = mapWebPacUrlToSCCURL(path, query);
-    expect(mapped).to.eql(`${BASE_SCC_URL}/account`);
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
+    expect(mapped).to.eql(`${BASE_SCC_URL}/account?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fpatroninfo%2F1234567`);
   });
 });
 


### PR DESCRIPTION
- Adds a new method to reconstruct the original url
- Adds the `originalUrl` param in the new (redirected) url.
- Fixes the tests to expect this parameter
- Updates the sample events to include `host`