### PR TITLE
Scc 2609

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const {
   BASE_SCC_URL,
-  CLASSIC_CATALOG_URL,
   LEGACY_CATALOG_URL,
 } = process.env;
 
@@ -160,6 +159,5 @@ module.exports = {
   indexMappings,
   handler,
   BASE_SCC_URL,
-  CLASSIC_CATALOG_URL,
   LEGACY_CATALOG_URL,
 };

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ const handler = async (event, context, callback) => {
     let redirectLocation = `${proto}://${mappedUrl}`;
     const response = {
       isBase64Encoded: false,
-      statusCode: 301,
+      statusCode: 302,
       multiValueHeaders: {
         Location: [redirectLocation],
       },
@@ -143,7 +143,7 @@ const handler = async (event, context, callback) => {
     let redirectLocation = `${proto}://${mappedUrl}`;
     const response = {
       isBase64Encoded: false,
-      statusCode: 301,
+      statusCode: 302,
       multiValueHeaders: {
         Location: [redirectLocation],
       },

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const {
   BASE_SCC_URL,
   CLASSIC_CATALOG_URL,
+  LEGACY_CATALOG_URL,
 } = process.env;
 
 
@@ -72,14 +73,28 @@ const expressions = {
       return `${BASE_SCC_URL}/bib/${bnum}`;
     }
   },
+  legacyReg: {
+    expr: /pinreset|selfreg/,
+    handler: (match, query) => {
+        return `${LEGACY_CATALOG_URL}${match.input}${reconstructQuery(query)}`
+    }
+  },
 };
+
+function reconstructQuery(query) {
+  const reconstructedQuery = Object.entries(query).map(([key, values]) => {
+      return values.map(value => value.length ? `${key}=${value}` : key).join('&')
+    })
+    .join('&');
+  return reconstructedQuery.length ? `?${reconstructedQuery}` : ''
+}
 
 function reconstructOriginalURL(path, query, host, proto) {
   const reconstructedQuery = Object.entries(query).map(([key, values]) => {
       return values.map(value => value.length ? `${key}=${value}` : key).join('&')
     })
     .join('&');
-  return encodeURIComponent(`${proto}://${host}${path}${reconstructedQuery.length ? '?' : ''}${reconstructedQuery}`);
+  return encodeURIComponent(`${proto}://${host}${path}${reconstructQuery(query)}`);
 }
 
 // The main method to build the redirectURL based on the incoming request
@@ -96,7 +111,9 @@ function mapWebPacUrlToSCCURL(path, query, host, proto) {
       }
   }
   if (!redirectURL) redirectURL = `${BASE_SCC_URL}/404/redirect`;
-  redirectURL = redirectURL + (redirectURL.includes('?') ? '&' : '?') + 'originalUrl=' + reconstructOriginalURL(path, query, host, proto);
+  if (!redirectURL.includes(LEGACY_CATALOG_URL)) {
+    redirectURL = redirectURL + (redirectURL.includes('?') ? '&' : '?') + 'originalUrl=' + reconstructOriginalURL(path, query, host, proto);
+  }
   return redirectURL;
 }
 
@@ -107,6 +124,7 @@ const handler = async (event, context, callback) => {
     let query = event.multiValueQueryStringParameters || {};
     let proto = event.multiValueHeaders['x-forwarded-proto'][0] ;
     let host = event.multiValueHeaders.host[0];
+
     let mappedUrl = mapWebPacUrlToSCCURL(path, query, host, proto);
     let redirectLocation = `${proto}://${mappedUrl}`;
     const response = {
@@ -142,4 +160,6 @@ module.exports = {
   indexMappings,
   handler,
   BASE_SCC_URL,
+  CLASSIC_CATALOG_URL,
+  LEGACY_CATALOG_URL,
 };

--- a/pinreset_event.json
+++ b/pinreset_event.json
@@ -1,0 +1,10 @@
+{
+  "path": "/pinreset~S1",
+  "multiValueHeaders": {
+    "x-forwarded-proto": [
+      "https"
+    ],
+    "host": ["qa-catalog.nypl.org"]
+  },
+  "multiValueQueryStringParameters": {}
+}

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -9,7 +9,6 @@ Globals:
     Environment:
       Variables:
         BASE_SCC_URL: qa-discovery.nypl.org/research/collections/shared-collection-catalog
-        CLASSIC_CATALOG_URL: qa-catalog.nypl.org
         LEGACY_CATALOG_URL: catalog.nypl.org
 
 Resources:

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -9,11 +9,8 @@ Globals:
     Environment:
       Variables:
         BASE_SCC_URL: qa-discovery.nypl.org/research/collections/shared-collection-catalog
-        CLASSIC_CATALOG_URL: https://catalog.nypl.org
-        CLIENT_ID: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGkwZwYJKoZIhvcNAQcGoFowWAIBADBTBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDMH033iRCWL2fqZIHgIBEIAmPHu+9wBZjnZSqLa4HMi2U33pHdmVFo2pfx5nrKKYCicoyAUHhJU=
-        CLIENT_SECRET: AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIcwgYQGCSqGSIb3DQEHBqB3MHUCAQAwcAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAwbvdh+2ByuGqN69hkCARCAQwceJ6Hc6gHSYvPsde6e3zrAXiC676UO1ICVVYRmEGYh6R4wwuEFi5RuQoZXBVIDiwoMM/iE0KkQjoKE7TQghDEp1yM=
-        OAUTH_URL: https://isso.nypl.org/oauth/token
-        PLATFORM_BASE_URL: https://qa-platform.nypl.org/api/v0.1
+        CLASSIC_CATALOG_URL: qa-catalog.nypl.org
+        LEGACY_CATALOG_URL: catalog.nypl.org
 
 Resources:
   RedirectService:

--- a/selfreg_event.json
+++ b/selfreg_event.json
@@ -1,0 +1,10 @@
+{
+  "path": "/screens/selfregpick.html",
+  "multiValueHeaders": {
+    "x-forwarded-proto": [
+      "https"
+    ],
+    "host": ["qa-catalog.nypl.org"]
+  },
+  "multiValueQueryStringParameters": {}
+}

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const env = require('./test.js');
-const { mapWebPacUrlToSCCURL, handler, BASE_SCC_URL, LEGACY_CATALOG_URL, CLASSIC_CATALOG_URL } = require('../../index.js');
+const { mapWebPacUrlToSCCURL, handler, BASE_SCC_URL, LEGACY_CATALOG_URL } = require('../../index.js');
 const axios = require('axios');
 
 let host = 'catalog.nypl.org';
@@ -111,7 +111,7 @@ describe('mapWebPacUrlToSCCURL', function() {
   });
 
   it('should redirect to legacy for pinreset pages', () => {
-    host = CLASSIC_CATALOG_URL;
+    host = 'qa-catalog.nypl.org';
     const path = '/pinreset~S1'
     const query = {};
     const mappedUrl = mapWebPacUrlToSCCURL(path, query, host, method);
@@ -120,7 +120,7 @@ describe('mapWebPacUrlToSCCURL', function() {
   });
 
   it('should redirect to legacy for selfreg pages', () => {
-    host = CLASSIC_CATALOG_URL;
+    host = 'qa-catalog.nypl.org';
     const path = '/screens/selfregpick.html'
     const query = {};
     const mappedUrl = mapWebPacUrlToSCCURL(path, query, host, method);

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -1,9 +1,9 @@
 const { expect } = require('chai');
 const env = require('./test.js');
-const { mapWebPacUrlToSCCURL, handler, BASE_SCC_URL } = require('../../index.js');
+const { mapWebPacUrlToSCCURL, handler, BASE_SCC_URL, LEGACY_CATALOG_URL, CLASSIC_CATALOG_URL } = require('../../index.js');
 const axios = require('axios');
 
-const host = 'catalog.nypl.org';
+let host = 'catalog.nypl.org';
 const method = 'https';
 
 describe('mapWebPacUrlToSCCURL', function() {
@@ -109,6 +109,24 @@ describe('mapWebPacUrlToSCCURL', function() {
     const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
     expect(mapped).to.eql(`${BASE_SCC_URL}/account?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fpatroninfo%2F1234567`);
   });
+
+  it('should redirect to legacy for pinreset pages', () => {
+    host = CLASSIC_CATALOG_URL;
+    const path = '/pinreset~S1'
+    const query = {};
+    const mappedUrl = mapWebPacUrlToSCCURL(path, query, host, method);
+    expect(mappedUrl)
+      .to.eql('https://catalog.nypl.org/pinreset~S1');
+  });
+
+  it('should redirect to legacy for selfreg pages', () => {
+    host = CLASSIC_CATALOG_URL;
+    const path = '/screens/selfregpick.html'
+    const query = {};
+    const mappedUrl = mapWebPacUrlToSCCURL(path, query, host, method);
+    expect(mappedUrl)
+      .to.eql('https://catalog.nypl.org/screens/selfregpick.html');
+  })
 });
 
 describe('handler', () => {

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -133,7 +133,7 @@ describe('handler', () => {
   const context = {};
   const callback = (_, resp) => resp.statusCode;
 
-  it('should call the callback with 301 response for matching url', async function () {
+  it('should call the callback with 302 response for matching url', async function () {
     const event = {
       path: '/',
       multiValueHeaders: {
@@ -142,10 +142,10 @@ describe('handler', () => {
     }
 
     const resp = await handler(event, context, callback);
-    expect(resp).to.eql(301);
+    expect(resp).to.eql(302);
   });
 
-  it('should call the callback with 301 response for non-matching url', async function () {
+  it('should call the callback with 302 response for non-matching url', async function () {
     // the record id here is just nonsense. It shouldn't match anything.
     const event = {
         path: '/record=&%!^/',
@@ -155,6 +155,6 @@ describe('handler', () => {
     }
 
     const resp = await handler(event, context, callback);
-    expect(resp).to.eql(301);
+    expect(resp).to.eql(302);
   });
 })

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -1,1 +1,3 @@
 process.env.BASE_SCC_URL = 'https://discovery.nypl.org'
+process.env.CLASSIC_CATALOG_URL = 'https://qa-catalog.nypl.org'
+process.env.LEGACY_CATALOG_URL = 'https://catalog.nypl.org'

--- a/test/unit/test.js
+++ b/test/unit/test.js
@@ -1,3 +1,2 @@
 process.env.BASE_SCC_URL = 'https://discovery.nypl.org'
-process.env.CLASSIC_CATALOG_URL = 'https://qa-catalog.nypl.org'
 process.env.LEGACY_CATALOG_URL = 'https://catalog.nypl.org'


### PR DESCRIPTION
- Adds redirecting to the Legacy Catalog for `selfreg` and `pinreset` pages, which aren't implemented in SCC.
- Adds tests and events to cover the above
- Changes `301` response to `302` and changes corresponding tests.
- Adds new variables / removes unnecessary variables in `sam.local.yml`

Note: Currently using `qa-catalog.nypl.org` as the Classic Catalog and `catalog.nypl.org` as the Legacy Catalog, since we don't have a QA Legacy Catalog. In production, `catalog.nypl.org` will be the Classic Catalog and the new legacy url will be the Legacy Catalog.