### PR TITLE
Add LANG param

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,11 +55,11 @@ const expressions = {
     handler: () => BASE_SCC_URL,
   },
   searchRegWith: {
-    expr: /\/search(~S\d*)?\/([a-zA-Z])(([^\/])+)/,
+    expr: /\/search(~S\w*)?\/([a-zA-Z])(([^\/])+)/,
     handler: match => `${BASE_SCC_URL}/search?q=${recodeSearchQuery(match[3])}${getIndexMapping(match[2])}`
   },
   searchRegWithout: {
-    expr: /\/search(~S\d*)?(\/([a-zA-Z]))?/,
+    expr: /\/search(~S\w*)?(\/([a-zA-Z]))?/,
     handler: (match, query) => `${BASE_SCC_URL}/search?q=${getQueryFromParams(match[0], query)}${getIndexMapping(match[3])}`
   },
   patroninfoReg: {

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -32,6 +32,14 @@ describe('mapWebPacUrlToSCCURL', function() {
       .to.eql(`${BASE_SCC_URL}/search?q=Rubina%2C%20Dina&search_scope=contributor&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S1%2FaRubina%252C%2BDina%2Farubina%2Bdina%2F1%252C2%252C84%252CB%2Fexact%26FF%3Darubina%2Bdina%2Bauthor%261%252C-1%252C%2Findexsort%3D-)`)
   });
 
+  it('should allow LANG in/Xsearchterm', function() {
+    const path = '/search~S1ENG/aRubina%2C+Dina/arubina+dina/1%2C2%2C84%2CB/exact&FF=arubina+dina+author&1%2C-1%2C/indexsort=-)';
+    const query = {};
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
+    expect(mapped)
+      .to.eql(`${BASE_SCC_URL}/search?q=Rubina%2C%20Dina&search_scope=contributor&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S1ENG%2FaRubina%252C%2BDina%2Farubina%2Bdina%2F1%252C2%252C84%252CB%2Fexact%26FF%3Darubina%2Bdina%2Bauthor%261%252C-1%252C%2Findexsort%3D-)`)
+  });
+
   it('should map search pages with index but no search term', function() {
     const path = '/search/t';
     const query = {};
@@ -58,6 +66,26 @@ describe('mapWebPacUrlToSCCURL', function() {
 
     expect(mapped)
       .to.eql(`${BASE_SCC_URL}/search?q=winspeare,%20j&search_scope=contributor&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S1%2F%3Fsearchtype%3Da%26searcharg%3Dwinspeare%2C%20j%26searchscope%3D1%26sortdropdown%3D-%26SORT%3DD%26extended%3D0%26SUBMIT%3DSearch%26searchlimits%26searchorigarg%3Ddmystery`)
+  });
+
+  it('should allow LANG as param in searches with searcharg and searchtype given as parameters', function() {
+    const path = '/search~S1ENG/';
+    const query = {
+      searchtype: ['a'],
+      searcharg: ['winspeare, j'],
+      searchscope: ['1'],
+      sortdropdown: ['-'],
+      SORT: ['D'],
+      extended: ['0'],
+      SUBMIT: ['Search'],
+      searchlimits: [''],
+      searchorigarg: ['dmystery'],
+    };
+
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
+
+    expect(mapped)
+      .to.eql(`${BASE_SCC_URL}/search?q=winspeare,%20j&search_scope=contributor&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S1ENG%2F%3Fsearchtype%3Da%26searcharg%3Dwinspeare%2C%20j%26searchscope%3D1%26sortdropdown%3D-%26SORT%3DD%26extended%3D0%26SUBMIT%3DSearch%26searchlimits%26searchorigarg%3Ddmystery`)
   });
 
   it('should map search pages with SEARCH given as parameter', function() {


### PR DESCRIPTION
Many of Chris's tests are errorring because `catalog.nypl.org` allows a `LANG` parameter for search pages, which the Redirect Service is unaware of. This PR makes the search-related regexes more permissive to allow for this parameter. The new regex is probably overly permissive -- I think it should be fine, but let me know if you foresee any issues.