### PR TITLE
Add mapping of search pages with no query to homepage

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const getQueryFromParams = (url, query) => {
     }
   }
   const q = searchArg || searchArgAlt || searchArgFromQueryParam || '';
+  if (!q.length) return null;
   const searchType = getParam('searchtype') || searchIndex;
   return recodeSearchQuery(q + (searchType ? getIndexMapping(searchType) : ''));
 }
@@ -59,7 +60,11 @@ const expressions = {
   },
   searchRegWithout: {
     expr: /\/search(~S\w*)?(\/([a-zA-Z]))?/,
-    handler: (match, query) => `${BASE_SCC_URL}/search?q=${getQueryFromParams(match[0], query)}${getIndexMapping(match[3])}`
+    handler: (match, query) => {
+      const mappedQuery = getQueryFromParams(match[0], query);
+      if (!mappedQuery) return BASE_SCC_URL;
+      return `${BASE_SCC_URL}/search?q=${mappedQuery}${getIndexMapping(match[3])}`;
+    }
   },
   patroninfoReg: {
     expr: /^\/patroninfo/,

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -40,13 +40,27 @@ describe('mapWebPacUrlToSCCURL', function() {
       .to.eql(`${BASE_SCC_URL}/search?q=Rubina%2C%20Dina&search_scope=contributor&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S1ENG%2FaRubina%252C%2BDina%2Farubina%2Bdina%2F1%252C2%252C84%252CB%2Fexact%26FF%3Darubina%2Bdina%2Bauthor%261%252C-1%252C%2Findexsort%3D-)`)
   });
 
-  it('should map search pages with index but no search term', function() {
+  it('should map search pages with index but no search term to the base url', function() {
     const path = '/search/t';
     const query = {};
     const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
-    expect(mapped)
-      .to.eql(`${BASE_SCC_URL}/search?q=&search_scope=title&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch%2Ft`)
+    expect(mapped).to.eql(`${BASE_SCC_URL}?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch%2Ft`);
   });
+
+  it('should map search pages with no index and no search term to the base url', function() {
+    const path = '/search';
+    const query = {};
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
+    expect(mapped).to.eql(`${BASE_SCC_URL}?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch`);
+  });
+
+  it('should map search pages with no index and no search term, plus screen type to the base url', function() {
+    const path = '/search~S98';
+    const query = {};
+    const mapped = mapWebPacUrlToSCCURL(path, query, host, method);
+    expect(mapped).to.eql(`${BASE_SCC_URL}?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S98`);
+  });
+
 
   it('should map search pages with searcharg and searchtype given as parameters', function() {
     const path = '/search~S1/';


### PR DESCRIPTION
For scc-2644, we want to map search pages with no query to the homepage, instead of mapping them to search results pages for the empty string. This PR adds the relevant logic and tests.