### PR TITLE
Scc 2736

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,18 @@ const expressions = {
     expr: /^\/$/,
     handler: () => BASE_SCC_URL,
   },
+  oclc: {
+    expr: /\/search\/o\=?(\d+)/,
+    handler: match => `${BASE_SCC_URL}/search?oclc=${match[1]}&redirectOnMatch=true`,
+  },
+  issn: {
+    expr: /\/search\/i(\d{4}\-\d{4})/,
+    handler: match => `${BASE_SCC_URL}/search?issn=${match[1]}&redirectOnMatch=true`,
+  },
+  isbn: {
+    expr: /\/search\/i(\w+)/,
+    handler: match => `${BASE_SCC_URL}/search?isbn=${match[1]}&redirectOnMatch=true`,
+  },
   searchRegWith: {
     expr: /\/search(~S\w*)?\/([a-zA-Z])(([^\/])+)/,
     handler: match => `${BASE_SCC_URL}/search?q=${recodeSearchQuery(match[3])}${getIndexMapping(match[2])}`
@@ -110,6 +122,7 @@ function mapWebPacUrlToSCCURL(path, query, host, proto) {
   for (let pathType of Object.values(expressions)) {
       const match = path.match(pathType.expr);
       if (match) {
+        console.log('expr: ', pathType.expr);
         redirectURL = pathType.handler(match, query);
         break
       }

--- a/index.js
+++ b/index.js
@@ -122,7 +122,6 @@ function mapWebPacUrlToSCCURL(path, query, host, proto) {
   for (let pathType of Object.values(expressions)) {
       const match = path.match(pathType.expr);
       if (match) {
-        console.log('expr: ', pathType.expr);
         redirectURL = pathType.handler(match, query);
         break
       }

--- a/oclcEvent.json
+++ b/oclcEvent.json
@@ -1,0 +1,10 @@
+{
+  "path": "/search/o248718131?fbclid=IwAR3iQaNePz2pd1JgoefSEgEbc9mAHnZiXXqY3BfeKp-kTui5lrlT_NDsSfE",
+  "multiValueHeaders": {
+    "x-forwarded-proto": [
+      "https"
+    ],
+    "host": ["catalog.nypl.org"]
+  },
+  "multiValueQueryStringParameters": {}
+}

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -137,6 +137,48 @@ describe('mapWebPacUrlToSCCURL', function() {
       .to.eql(`${BASE_SCC_URL}/search?q=brainwash&search_scope=title&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S97%3F%2Ftbrainwash%2Ftbrainwash%2F1%2C3%2C10%2CB%2Fexact%26FF%3Dtbrainwash%261%2C4%2C`)
   });
 
+  it('should map search pages for oclc records', () => {
+    const path = '/search/o1081334684';
+    const mapped = mapWebPacUrlToSCCURL(path, {}, host, method);
+    expect(mapped)
+      .to.include(`${BASE_SCC_URL}/search?oclc=1081334684&redirectOnMatch=true`);
+  });
+
+  it('should map search pages for oclc records including =', () => {
+    const path = '/search/o=75307280';
+    const mapped = mapWebPacUrlToSCCURL(path, {}, host, method);
+    expect(mapped)
+      .to.include(`${BASE_SCC_URL}/search?oclc=75307280&redirectOnMatch=true`);
+  });
+
+  it('should map search pages for issn numbers', () => {
+    const path = '/search/i0012-9976';
+    const mapped = mapWebPacUrlToSCCURL(path, {}, host, method);
+    expect(mapped)
+      .to.include(`${BASE_SCC_URL}/search?issn=0012-9976&redirectOnMatch=true`);
+  });
+
+  it('should map search pages for short isbn numbers', () => {
+    const path = '/search/i1465351078';
+    const mapped = mapWebPacUrlToSCCURL(path, {}, host, method);
+    expect(mapped)
+      .to.include(`${BASE_SCC_URL}/search?isbn=1465351078&redirectOnMatch=true`);
+  })
+
+  it('should map search pages for long isbn numbers', () => {
+    const path = '/search/i9781568987873';
+    const mapped = mapWebPacUrlToSCCURL(path, {}, host, method);
+    expect(mapped)
+      .to.include(`${BASE_SCC_URL}/search?isbn=9781568987873&redirectOnMatch=true`);
+  });
+
+  it('should map search pages for isbn numbers including X', () => {
+    const path = '/search/i178694135X';
+    const mapped = mapWebPacUrlToSCCURL(path, {}, host, method);
+    expect(mapped)
+      .to.include(`${BASE_SCC_URL}/search?isbn=178694135X&redirectOnMatch=true`)
+  });
+
   it('should return 404 page if no match is found', function() {
     const path = '/record=&%!^/';
     const query = {};


### PR DESCRIPTION
- Adds new logic to handle search paths for oclc, issn, and isbn numbers and redirect to the corresponding paths in RC.
- Adds corresponding tests