### PR TITLE
include iii/encore as path

### DIFF
--- a/expressions.js
+++ b/expressions.js
@@ -10,7 +10,7 @@ const { getQueryFromParams, recodeSearchQuery, reconstructQuery, getIndexMapping
 module.exports = {
   nothingReg: {
     // empty path or /bookcart, /home endpoint (from encore)
-    expr: /(?:^\/$)|bookcart$|home$/,
+    expr: /(?:^\/$)|(?:^\/iii\/encore$)|bookcart$|home$/,
         handler: homeHandler
   },
   rc_from_vega: {

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -294,7 +294,7 @@ describe('mapToRedirectURL', function () {
   describe('encore links', () => {
     let encoreHost = 'browse.nypl.org'
     it('should map the base URL correctly', function () {
-      const path = '/';
+      const path = '/iii/encore';
       const query = {};
       const mapped = mapToRedirectURL(path, query, encoreHost, method);
       expect(mapped)


### PR DESCRIPTION
the load balancer automatically removes any path, so we have to explicitly include /iii/encore as the home path.