### PR TITLE
SCC-3507:  Redirect Encore logout endpoint through Vega

### DIFF
--- a/expressions.js
+++ b/expressions.js
@@ -3,7 +3,8 @@ const {
   LEGACY_CATALOG_URL,
   ENCORE_URL,
   VEGA_URL,
-  CAS_SERVER_DOMAIN
+  CAS_SERVER_DOMAIN,
+  VEGA_AUTH_DOMAIN
 } = process.env;
 
 const {
@@ -108,9 +109,8 @@ module.exports = {
   },
   /**
    *  Handle requests on //browse.nypl.org/iii/encore/logoutFilterRedirect
-   *  Emulate Encore behavior by redirecting to the CAS logout endpoint,
-   *  passing either the given service= param or Vega Home.
-   *  (The service= param controls where CAS redirects to after logout.)
+   *  Redirect requests to the Vega Auth logout endpoint (which in turn should
+   *  redirect the patron through the CAS Logout endpoint)
    */
   encoreLogoutFilterRedirect: {
     expr: /^\/iii\/encore\/logoutFilterRedirect\b/,
@@ -119,7 +119,7 @@ module.exports = {
       const redirectToAfterLogout = validRedirectUrl(redirectUri)
         ? redirectUri
         : `https://${VEGA_URL}/search`
-      return `${CAS_SERVER_DOMAIN}/iii/cas/logout?service=${redirectToAfterLogout}`
+      return `${VEGA_AUTH_DOMAIN}/auth/realms/nypl/protocol/openid-connect/logout?redirect_uri=${redirectToAfterLogout}`
     }
   }
 };

--- a/expressions.js
+++ b/expressions.js
@@ -3,7 +3,6 @@ const {
   LEGACY_CATALOG_URL,
   ENCORE_URL,
   VEGA_URL,
-  CAS_SERVER_DOMAIN,
   VEGA_AUTH_DOMAIN
 } = process.env;
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const handler = async (event, context, callback) => {
     if (query && query['redirect-service-debug']) {
       return callback(null, {
         statusCode: 200,
-        headers: { 'Content-type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ input: { query, proto, host, path, event }, redirectLocation })
       })
     }

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -8,12 +8,13 @@ Globals:
     Timeout: 300
     Environment:
       Variables:
-        BASE_SCC_URL: qa-www.nypl.org/research/research-catalog
+        BASE_SCC_URL: www.nypl.org/research/research-catalog
         LEGACY_CATALOG_URL: legacycatalog.nypl.org
         ENCORE_URL: browse.nypl.org
         VEGA_URL: nypl.na2.iiivega.com
         ENCORE_URL: browse.nypl.org
         CAS_SERVER_DOMAIN: ilsstaff.nypl.org
+        VEGA_AUTH_DOMAIN: auth.na2.iiivega.com
 Resources:
   RedirectService:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -13,7 +13,6 @@ Globals:
         ENCORE_URL: browse.nypl.org
         VEGA_URL: nypl.na2.iiivega.com
         ENCORE_URL: browse.nypl.org
-        CAS_SERVER_DOMAIN: ilsstaff.nypl.org
         VEGA_AUTH_DOMAIN: auth.na2.iiivega.com
 Resources:
   RedirectService:

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -449,12 +449,12 @@ describe('handler', () => {
       }
     }
 
-    it('should redirect Encore logout URL to CAS logout endpoint', async function () {
+    it('should redirect Encore logout URL to Vega Auth logout endpoint', async function () {
       const resp = await handler(baseEvent, context, (_, resp) => resp);
       expect(resp).to.deep.eql({
         isBase64Encoded: false,
         statusCode: 302,
-        multiValueHeaders: { Location: [ 'https://ilsstaff.nypl.org/iii/cas/logout?service=https://nypl.na2.iiivega.com/search' ] }
+        multiValueHeaders: { Location: [ 'https://auth.na2.iiivega.com/auth/realms/nypl/protocol/openid-connect/logout?redirect_uri=https://nypl.na2.iiivega.com/search' ] }
       })
     })
 
@@ -474,7 +474,7 @@ describe('handler', () => {
         const resp = await handler(eventWithRedirect, context, (_, resp) => resp);
         expect(resp).to.deep.include({
           statusCode: 302,
-          multiValueHeaders: { Location: [ `https://ilsstaff.nypl.org/iii/cas/logout?service=${validUrl}` ] }
+          multiValueHeaders: { Location: [ `https://auth.na2.iiivega.com/auth/realms/nypl/protocol/openid-connect/logout?redirect_uri=${validUrl}` ] }
         })
       })
     })
@@ -486,7 +486,7 @@ describe('handler', () => {
       const resp = await handler(eventWithRedirect, context, (_, resp) => resp);
       expect(resp).to.deep.include({
         statusCode: 302,
-        multiValueHeaders: { Location: [ 'https://ilsstaff.nypl.org/iii/cas/logout?service=https://nypl.na2.iiivega.com/search' ] }
+        multiValueHeaders: { Location: [ 'https://auth.na2.iiivega.com/auth/realms/nypl/protocol/openid-connect/logout?redirect_uri=https://nypl.na2.iiivega.com/search' ] }
       })
     })
   })

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -458,15 +458,24 @@ describe('handler', () => {
       })
     })
 
-    it('should respect redirect_uri param', async function () {
-      const rcUrl = 'https://www.nypl.org/research/research-catalog'
-      const eventWithRedirect = Object.assign( {}, baseEvent,
-        { multiValueQueryStringParameters: { redirect_uri: [ rcUrl ] } }
-      )
-      const resp = await handler(eventWithRedirect, context, (_, resp) => resp);
-      expect(resp).to.deep.include({
-        statusCode: 302,
-        multiValueHeaders: { Location: [ `https://ilsstaff.nypl.org/iii/cas/logout?service=${rcUrl}` ] }
+    // Test several allowed redirect_uris:
+    ; [
+      'https://www.nypl.org/',
+      'https://browse.nypl.org/',
+      'https://legacycatalog.nypl.org/',
+      'https://nypl.na2.iiivega.com/',
+      'https://www.nypl.org/research/research-catalog',
+      'https://auth.na2.iiivega.com/auth/realms/nypl/protocol/openid-connect/logout?redirect_uri=https://www.nypl.org/research/research-catalog/bib/b11373666'
+    ].forEach((validUrl) => {
+      it(`should respect redirect_uri=${validUrl}`, async function () {
+        const eventWithRedirect = Object.assign( {}, baseEvent,
+          { multiValueQueryStringParameters: { redirect_uri: [ validUrl ] } }
+        )
+        const resp = await handler(eventWithRedirect, context, (_, resp) => resp);
+        expect(resp).to.deep.include({
+          statusCode: 302,
+          multiValueHeaders: { Location: [ `https://ilsstaff.nypl.org/iii/cas/logout?service=${validUrl}` ] }
+        })
       })
     })
 
@@ -480,6 +489,5 @@ describe('handler', () => {
         multiValueHeaders: { Location: [ 'https://ilsstaff.nypl.org/iii/cas/logout?service=https://nypl.na2.iiivega.com/search' ] }
       })
     })
-
   })
 })

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -5,6 +5,7 @@ const loadTestEnvironment = () => {
   process.env.ENCORE_URL = 'browse.nypl.org'
   process.env.VEGA_URL = 'nypl.na2.iiivega.com'
   process.env.CAS_SERVER_DOMAIN = 'ilsstaff.nypl.org'
+  process.env.VEGA_AUTH_DOMAIN = 'auth.na2.iiivega.com'
 }
 
 module.exports = {

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -4,7 +4,6 @@ const loadTestEnvironment = () => {
   process.env.LEGACY_CATALOG_URL = 'legacycatalog.nypl.org'
   process.env.ENCORE_URL = 'browse.nypl.org'
   process.env.VEGA_URL = 'nypl.na2.iiivega.com'
-  process.env.CAS_SERVER_DOMAIN = 'ilsstaff.nypl.org'
   process.env.VEGA_AUTH_DOMAIN = 'auth.na2.iiivega.com'
 }
 

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -19,7 +19,6 @@ describe('utils', function () {
       expect(utils.validRedirectUrl('https://legacycatalog.nypl.org/')).to.eq(true)
       expect(utils.validRedirectUrl('https://www.nypl.org/research/research-catalog')).to.eq(true)
       expect(utils.validRedirectUrl('https://nypl.na2.iiivega.com/')).to.eq(true)
-      expect(utils.validRedirectUrl('https://auth.na2.iiivega.com/')).to.eq(true)
     })
   })
 })

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -10,12 +10,16 @@ describe('utils', function () {
       expect(utils.validRedirectUrl('https://duckduckgo.com')).to.eq(false)
       expect(utils.validRedirectUrl('https://duckduckgo.com?q=https://catalog.nypl.org')).to.eq(false)
       expect(utils.validRedirectUrl('https://www.nypl.org.us')).to.eq(false)
+      // Require a trailing slash:
+      expect(utils.validRedirectUrl('https://nypl.na2.iiivega.com')).to.eq(false)
     })
 
     it('should mark known domains as valid', function () {
       expect(utils.validRedirectUrl('https://www.nypl.org/')).to.eq(true)
       expect(utils.validRedirectUrl('https://legacycatalog.nypl.org/')).to.eq(true)
       expect(utils.validRedirectUrl('https://www.nypl.org/research/research-catalog')).to.eq(true)
+      expect(utils.validRedirectUrl('https://nypl.na2.iiivega.com/')).to.eq(true)
+      expect(utils.validRedirectUrl('https://auth.na2.iiivega.com/')).to.eq(true)
     })
   })
 })

--- a/utils.js
+++ b/utils.js
@@ -68,7 +68,8 @@ function validRedirectUrl (url) {
   if (!url) return false
 
   const wwwDomain = BASE_SCC_URL.split('/')[0]
-  return [wwwDomain, ENCORE_URL, LEGACY_CATALOG_URL, VEGA_URL]
+  const vegaAuthDomain = VEGA_URL.replace(/^nypl\./, 'auth.')
+  return [wwwDomain, ENCORE_URL, LEGACY_CATALOG_URL, VEGA_URL, vegaAuthDomain]
     .map((domain) => `https://${domain}/`)
     .some((baseUrl) => url.indexOf(baseUrl) === 0)
 }

--- a/utils.js
+++ b/utils.js
@@ -2,6 +2,7 @@ const {
   BASE_SCC_URL,
   LEGACY_CATALOG_URL,
   VEGA_URL,
+  VEGA_AUTH_DOMAIN,
   ENCORE_URL
 } = process.env;
 
@@ -68,8 +69,7 @@ function validRedirectUrl (url) {
   if (!url) return false
 
   const wwwDomain = BASE_SCC_URL.split('/')[0]
-  const vegaAuthDomain = VEGA_URL.replace(/^nypl\./, 'auth.')
-  return [wwwDomain, ENCORE_URL, LEGACY_CATALOG_URL, VEGA_URL, vegaAuthDomain]
+  return [wwwDomain, ENCORE_URL, LEGACY_CATALOG_URL, VEGA_URL, VEGA_AUTH_DOMAIN]
     .map((domain) => `https://${domain}/`)
     .some((baseUrl) => url.indexOf(baseUrl) === 0)
 }


### PR DESCRIPTION
Instead of bouncing the patron directly to CAS when logging out,
let's bounce them to the Vega Auth logout endpoint to ensure they're
logged out there. Vega Auth will bounce them through CAS Logout, so this
should cause them lose both the Vega and CAS session.