### PR TITLE
Changing default page for Vega to be the homepage, not search

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function mapToRedirectURL (path, query, host, proto) {
   }
   // instead of a 404, we are just sending them to the landing page
   if (redirectingFromEncore && !redirectURL) {
-    redirectURL = VEGA_URL + '/search'
+    redirectURL = VEGA_URL + '/'
   }
   if (redirectingFromLegacyOrVegaToSCC) {
     if (!redirectURL) redirectURL = `${BASE_SCC_URL}/404/redirect`;

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -289,13 +289,13 @@ describe('mapToRedirectURL', function () {
   })
   describe('encore links', () => {
     const query = {}
-    let searchRedirect = VEGA_URL + '/search'
+    let homepage = VEGA_URL + '/'
     let encoreHost = process.env.ENCORE_URL
     it('should map the base URL correctly', function () {
       const path = '/iii/encore';
       const mapped = mapToRedirectURL(path, query, encoreHost, method);
       expect(mapped)
-        .to.eql(searchRedirect)
+        .to.eql(homepage)
     });
 
     it('should map bib pages correctly', function () {
@@ -312,7 +312,7 @@ describe('mapToRedirectURL', function () {
       const path = '/record/C__Rb18225028kindred__Orightresult__U__X7?lang=eng&suite=def'
       const mapped = mapToRedirectURL(path, query, encoreHost, method);
       expect(mapped)
-        .to.eql(searchRedirect)
+        .to.eql(homepage)
     })
     it('should redirect keyword search properly', () => {
       const path = '/search/C__SAncient%20Greece__Orightresult__U?lang=eng&suite=def'
@@ -342,13 +342,13 @@ describe('mapToRedirectURL', function () {
       const path = '/bookcart'
       const mapped = mapToRedirectURL(path, query, encoreHost, method);
       expect(mapped)
-        .to.eql(searchRedirect)
+        .to.eql(homepage)
     })
     it('/home redirects to /', () => {
       const path = '/home'
       const mapped = mapToRedirectURL(path, query, encoreHost, method);
       expect(mapped)
-        .to.eql(searchRedirect)
+        .to.eql(homepage)
     })
     it('should redirect account page', () => {
       const path = '/myaccount'

--- a/utils.js
+++ b/utils.js
@@ -17,7 +17,7 @@ const indexMappings = {
   i: '&search_scope=standard_number', // what to do with these?
   c: '&search_scope=standard_number',
 }
-const homeHandler = (match, query, host) => LEGACY_CATALOG_URL.includes(host) ? BASE_SCC_URL : VEGA_URL + '/search'
+const homeHandler = (match, query, host) => LEGACY_CATALOG_URL.includes(host) ? BASE_SCC_URL : VEGA_URL + '/'
 
 const getIndexMapping = index => indexMappings[index] || '';
 


### PR DESCRIPTION
This is basically for performance reasons. The decision to use the search page was a marginal one, so this isn't a big policy change; hopefully not a significant code change either.