### PR TITLE
Ensure patron logged out of CAS after vega logout

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ const {
   BASE_SCC_URL,
   LEGACY_CATALOG_URL,
   ENCORE_URL,
-  VEGA_URL
+  VEGA_URL,
+  REDIRECT_SERVICE_DOMAIN
 } = process.env;
 
 // The main method to build the redirectURL based on the incoming request
@@ -13,7 +14,7 @@ const {
 // As a default, returns the BASE_SCC_URL
 function mapToRedirectURL (path, query, host, proto) {
   const redirectingFromEncore = host === ENCORE_URL
-  const redirectingFromLegacyOrVegaToSCC = !redirectingFromEncore
+  const redirectingFromLegacyOrVegaToSCC = !redirectingFromEncore && host !== REDIRECT_SERVICE_DOMAIN
   let redirectURL;
   for (let pathType of Object.values(expressions)) {
     let match;
@@ -68,7 +69,7 @@ const handler = async (event, context, callback) => {
     if (query && query['redirect-service-debug']) {
       return callback(null, {
         statusCode: 200,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ input: { query, proto, host, path, event }, redirectLocation })
       })
     }
@@ -77,8 +78,8 @@ const handler = async (event, context, callback) => {
       isBase64Encoded: false,
       statusCode: 302,
       multiValueHeaders: {
-        Location: [redirectLocation],
-      },
+        Location: [redirectLocation]
+      }
     };
     return callback(null, response);
   }

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -14,6 +14,8 @@ Globals:
         VEGA_URL: nypl.na2.iiivega.com
         ENCORE_URL: browse.nypl.org
         VEGA_AUTH_DOMAIN: auth.na2.iiivega.com
+        CAS_SERVER_DOMAIN: ilsstaff.nypl.org
+        REDIRECT_SERVICE_DOMAIN: redir-browse.nypl.org
 Resources:
   RedirectService:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -5,6 +5,8 @@ const loadTestEnvironment = () => {
   process.env.ENCORE_URL = 'browse.nypl.org'
   process.env.VEGA_URL = 'nypl.na2.iiivega.com'
   process.env.VEGA_AUTH_DOMAIN = 'auth.na2.iiivega.com'
+  process.env.CAS_SERVER_DOMAIN = 'ilsstaff.nypl.org'
+  process.env.REDIRECT_SERVICE_DOMAIN = 'redir-browse.nypl.org'
 }
 
 module.exports = {

--- a/utils.js
+++ b/utils.js
@@ -74,6 +74,17 @@ function validRedirectUrl (url) {
     .some((baseUrl) => url.indexOf(baseUrl) === 0)
 }
 
+/**
+ *  Given a query hash, extracts and validates the request_uri, returning the
+ *  request_uri or a sensible default if it's invalid/missing.
+ */
+function getRedirectUri (query) {
+  const redirectUri = Array.isArray(query.redirect_uri) ? query.redirect_uri[0] : null
+  return validRedirectUrl(redirectUri)
+    ? redirectUri
+    : `https://${VEGA_URL}/`
+}
+
 module.exports = {
   getIndexMapping,
   reconstructQuery,
@@ -81,5 +92,6 @@ module.exports = {
   getQueryFromParams,
   recodeSearchQuery,
   homeHandler,
-  validRedirectUrl
+  validRedirectUrl,
+  getRedirectUri
 }


### PR DESCRIPTION
The Vega Logout route does not always route the user through the CAS Logout endpoint. This means that, after a user passes through the Vega Logout route, they may still be logged in to CAS. One way to ensure they are not logged in to CAS is to pass them through the CAS Logout route after they've gone through the Vega Logout route.

Adds a new route to the RedirectService:
/vega-logout-handler[?redirect_uri=...] . The new route accepts a valid redirect_uri and passes the user on through the CAS Logout route.

Modifies the Encore Logout handler to, before passing the patron on to the Vega Logout route, modifies the incoming redirect_uri to first hit the new Vega logout handler route so that the patron routes through CAS Logout after logging out of Vega.

This should ensure that patrons are logged out of both CAS and Vega after logging out of RC.