### PR TITLE
[SCC-3538] Remove console logs and add tests for collection param redirect

### DIFF
--- a/expressions.js
+++ b/expressions.js
@@ -99,7 +99,6 @@ module.exports = {
     expr: /\/record=(b\d{8})/,
     handler: (match, query) => {
       const { collection } = query;
-      console.log("query", query);
       const bnum = match[1];
       if (Array.isArray(collection) && collection.includes("circ")) {
         return `${VEGA_URL}/search/card?recordId=${bnum.replace(/\D/g, '')}`;

--- a/index.js
+++ b/index.js
@@ -52,7 +52,6 @@ const healthCheck = () => {
 };
 
 const handler = async (event, context, callback) => {
-  console.log(event);
   const headers = event.multiValueHeaders || {}
   const proto = Array.isArray(headers['x-forwarded-proto'])
     ? headers['x-forwarded-proto'][0]

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -455,57 +455,59 @@ describe('handler', () => {
     })
   });
 
-  it('should redirect to vega with converted bib id when "circ" set as collection query param', async function () {
-    const event = {
-      path: '/record=b22297361',
-      multiValueHeaders: {
-        'x-forwarded-proto': ['https'],
-        host: ['catalog.nypl.org']
-      },
-      multiValueQueryStringParameters: {
-        "collection": ["circ"]
+  describe('collection query param redirect', () => {
+    it('should redirect to vega with converted bib id when "circ" set as collection query param', async function () {
+      const event = {
+        path: '/record=b22297361',
+        multiValueHeaders: {
+          'x-forwarded-proto': ['https'],
+          host: ['catalog.nypl.org']
+        },
+        multiValueQueryStringParameters: {
+          "collection": ["circ"]
+        }
       }
-    }
-    const resp = await handler(event, context, (_, resp) => resp);
-    expect(resp).to.deep.include({
-      statusCode: 302,
-      multiValueHeaders: { Location: [ "https://nypl.na2.iiivega.com/search/card?recordId=22297361&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22297361%3Fcollection%3Dcirc" ] }
+      const resp = await handler(event, context, (_, resp) => resp);
+      expect(resp).to.deep.include({
+        statusCode: 302,
+        multiValueHeaders: { Location: [ "https://nypl.na2.iiivega.com/search/card?recordId=22297361&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22297361%3Fcollection%3Dcirc" ] }
+      })
     })
-  })
-
-  it('should redirect to vega when "circ" is included in multiple collection query params', async function () {
-    const event = {
-      path: '/record=b22297361',
-      multiValueHeaders: {
-        'x-forwarded-proto': ['https'],
-        host: ['catalog.nypl.org']
-      },
-      multiValueQueryStringParameters: {
-        "collection": ["circ", "research"]
+  
+    it('should redirect to vega when "circ" is included in multiple collection query params', async function () {
+      const event = {
+        path: '/record=b22297361',
+        multiValueHeaders: {
+          'x-forwarded-proto': ['https'],
+          host: ['catalog.nypl.org']
+        },
+        multiValueQueryStringParameters: {
+          "collection": ["circ", "research"]
+        }
       }
-    }
-    const resp = await handler(event, context, (_, resp) => resp);
-    expect(resp).to.deep.include({
-      statusCode: 302,
-      multiValueHeaders: { Location: [ "https://nypl.na2.iiivega.com/search/card?recordId=22297361&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22297361%3Fcollection%3Dcirc%26collection%3Dresearch" ] }
+      const resp = await handler(event, context, (_, resp) => resp);
+      expect(resp).to.deep.include({
+        statusCode: 302,
+        multiValueHeaders: { Location: [ "https://nypl.na2.iiivega.com/search/card?recordId=22297361&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22297361%3Fcollection%3Dcirc%26collection%3Dresearch" ] }
+      })
     })
-  })
 
-  it('should redirect to research catalog when anything other than "circ" is in collection query params', async function () {
-    const event = {
-      path: '/record=b22297361',
-      multiValueHeaders: {
-        'x-forwarded-proto': ['https'],
-        host: ['catalog.nypl.org']
-      },
-      multiValueQueryStringParameters: {
-        "collection": ["research"]
+    it('should redirect to research catalog when anything other than "circ" is in collection query params', async function () {
+      const event = {
+        path: '/record=b22297361',
+        multiValueHeaders: {
+          'x-forwarded-proto': ['https'],
+          host: ['catalog.nypl.org']
+        },
+        multiValueQueryStringParameters: {
+          "collection": ["research"]
+        }
       }
-    }
-    const resp = await handler(event, context, (_, resp) => resp);
-    expect(resp).to.deep.include({
-      statusCode: 302,
-      multiValueHeaders: { Location: [ "https://www.nypl.org/research/research-catalog/bib/b22297361?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22297361%3Fcollection%3Dresearch" ] }
+      const resp = await handler(event, context, (_, resp) => resp);
+      expect(resp).to.deep.include({
+        statusCode: 302,
+        multiValueHeaders: { Location: [ "https://www.nypl.org/research/research-catalog/bib/b22297361?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22297361%3Fcollection%3Dresearch" ] }
+      })
     })
   })
 

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -491,6 +491,24 @@ describe('handler', () => {
     })
   })
 
+  it('should redirect to research catalog when anything other than "circ" is in collection query params', async function () {
+    const event = {
+      path: '/record=b22297361',
+      multiValueHeaders: {
+        'x-forwarded-proto': ['https'],
+        host: ['catalog.nypl.org']
+      },
+      multiValueQueryStringParameters: {
+        "collection": ["research"]
+      }
+    }
+    const resp = await handler(event, context, (_, resp) => resp);
+    expect(resp).to.deep.include({
+      statusCode: 302,
+      multiValueHeaders: { Location: [ "https://www.nypl.org/research/research-catalog/bib/b22297361?originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22297361%3Fcollection%3Dresearch" ] }
+    })
+  })
+
   describe('encore logout redirect', () => {
     const baseEvent = {
       path: '/iii/encore/logoutFilterRedirect',

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -455,6 +455,42 @@ describe('handler', () => {
     })
   });
 
+  it('should redirect to vega with converted bib id when "circ" set as collection query param', async function () {
+    const event = {
+      path: '/record=b22297361',
+      multiValueHeaders: {
+        'x-forwarded-proto': ['https'],
+        host: ['catalog.nypl.org']
+      },
+      multiValueQueryStringParameters: {
+        "collection": ["circ"]
+      }
+    }
+    const resp = await handler(event, context, (_, resp) => resp);
+    expect(resp).to.deep.include({
+      statusCode: 302,
+      multiValueHeaders: { Location: [ "https://nypl.na2.iiivega.com/search/card?recordId=22297361&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22297361%3Fcollection%3Dcirc" ] }
+    })
+  })
+
+  it('should redirect to vega when "circ" is included in multiple collection query params', async function () {
+    const event = {
+      path: '/record=b22297361',
+      multiValueHeaders: {
+        'x-forwarded-proto': ['https'],
+        host: ['catalog.nypl.org']
+      },
+      multiValueQueryStringParameters: {
+        "collection": ["circ", "research"]
+      }
+    }
+    const resp = await handler(event, context, (_, resp) => resp);
+    expect(resp).to.deep.include({
+      statusCode: 302,
+      multiValueHeaders: { Location: [ "https://nypl.na2.iiivega.com/search/card?recordId=22297361&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Frecord%3Db22297361%3Fcollection%3Dcirc%26collection%3Dresearch" ] }
+    })
+  })
+
   describe('encore logout redirect', () => {
     const baseEvent = {
       path: '/iii/encore/logoutFilterRedirect',


### PR DESCRIPTION
This PR simply adds tests for the already deployed Vega redirect logic.

It also removes the console logs I added for troubleshooting.