### PR TITLE
Add option to skip Auth.Vega logout

### DIFF
--- a/expressions.js
+++ b/expressions.js
@@ -121,6 +121,13 @@ module.exports = {
   encoreLogoutFilterRedirect: {
     expr: /^\/iii\/encore\/logoutFilterRedirect\b/,
     handler: (match, query) => {
+      // Optionally skip Vega Auth redirect:
+      if (process.env.SKIP_VEGA_LOGOUT === 'true') {
+        // Send patron straight to CAS logout endpoint, which would normally
+        // happen after hitting the Vega Auth logout endpoint.
+        return module.exports.vegaLogoutHandler.handler(match, query)
+      }
+
       const redirectToAfterLogout = getRedirectUri(query)
       const vegaLogoutHandlerRedirect = `https://${REDIRECT_SERVICE_DOMAIN}/vega-logout-handler?redirect_uri=${encodeURIComponent(redirectToAfterLogout)}`
       return `${VEGA_AUTH_DOMAIN}/auth/realms/nypl/protocol/openid-connect/logout?redirect_uri=${encodeURIComponent(vegaLogoutHandlerRedirect)}`


### PR DESCRIPTION
When `SKIP_VEGA_LOGOUT=true`, skip sending patrons through the Auth.Vega logout endpoint. This may cause some patrons to retain Vega auth sessions after logging out of the Research Catalog, but may be the best option if the Auth.vega logout endpoint is misbehaving (which may cause RC logout to fail entirely.