### PR TITLE
Fix vega logout

### DIFF
--- a/expressions.js
+++ b/expressions.js
@@ -133,7 +133,7 @@ module.exports = {
 
       // Set up Vega-logout route (for JS-enabled users):
       const vegaLogoutHandlerRedirect = `https://${REDIRECT_SERVICE_DOMAIN}/vega-logout-handler?redirect_uri=${encodeURIComponent(redirectToAfterLogout)}`
-      const vegaLogoutUri = `https://${VEGA_AUTH_DOMAIN}/logout?redirect_uri=${encodeURIComponent(vegaLogoutHandlerRedirect)}`
+      const vegaLogoutUri = `https://${VEGA_URL}/logout?redirect_uri=${encodeURIComponent(vegaLogoutHandlerRedirect)}`
 
       // Send user through js-conditional redirect:
       // - JS-enabled users will pass through Vega logout (which includes CAS)

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ const handler = async (event, context, callback) => {
       return callback(null, {
         statusCode: 200,
         multiValueHeaders: { 'content-type': ['application/json'] },
-        body: JSON.stringify({ input: { query, proto, host, path, event }, redirectLocation })
+        body: JSON.stringify({ input: { query, proto, host, path, event }, redirectLocation }, null, 2)
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,9 @@ const healthCheck = () => {
   const version = require('./package.json').version;
   return {
     isBase64Encoded: false,
+    multiValueHeaders: {
+      'Content-Type': ['application/json']
+    },
     statusCode: 200,
     body: JSON.stringify({ version })
   };
@@ -66,8 +69,9 @@ const healthCheck = () => {
 const jsConditionalRedirect = (jsRedirect, noscriptRedirect) => {
   return {
     statusCode: 200,
-    headers: {
-      'Content-Type': 'text/html'
+    isBase64Encoded: false,
+    multiValueHeaders: {
+      'Content-Type': ['text/html']
     },
     body: `<html>
         <head>

--- a/index.js
+++ b/index.js
@@ -65,12 +65,9 @@ const healthCheck = () => {
 */
 const jsConditionalRedirect = (jsRedirect, noscriptRedirect) => {
   return {
-    isBase64Encoded: false,
     statusCode: 200,
     headers: {
-      'Content-Type': 'text/html',
-      'Access-Control-Allow-Origin': "'*'",
-      'Access-Control-Allow-Methods': 'GET'
+      'Content-Type': 'text/html'
     },
     body: `<html>
         <head>

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const jsConditionalRedirect = (jsRedirect, noscriptRedirect) => {
     isBase64Encoded: false,
     statusCode: 200,
     headers: {
-      'Content-Type': 'text/html; charset=utf-8',
+      'Content-Type': 'text/html',
       'Access-Control-Allow-Origin': "'*'",
       'Access-Control-Allow-Methods': 'GET'
     },

--- a/index.js
+++ b/index.js
@@ -67,7 +67,11 @@ const jsConditionalRedirect = (jsRedirect, noscriptRedirect) => {
   return {
     isBase64Encoded: false,
     statusCode: 200,
-    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Access-Control-Allow-Origin': "'*'",
+      'Access-Control-Allow-Methods': 'GET'
+    },
     body: `<html>
         <head>
           <script type="text/javascript">window.location.replace("${jsRedirect}");</script>

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ const handler = async (event, context, callback) => {
     if (query && query['redirect-service-debug']) {
       return callback(null, {
         statusCode: 200,
-        headers: { 'content-type': 'application/json' },
+        multiValueHeaders: { 'content-type': ['application/json'] },
         body: JSON.stringify({ input: { query, proto, host, path, event }, redirectLocation })
       })
     }

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -8,14 +8,13 @@ Globals:
     Timeout: 300
     Environment:
       Variables:
-        BASE_SCC_URL: www.nypl.org/research/research-catalog
-        LEGACY_CATALOG_URL: legacycatalog.nypl.org
-        ENCORE_URL: browse.nypl.org
+        BASE_SCC_URL: qa-www.nypl.org/research/research-catalog
+        LEGACY_CATALOG_URL: nypl-sierra-test.nypl.org
+        ENCORE_URL: qa-redir-browse.nypl.org
         VEGA_URL: nypl.na2.iiivega.com
-        ENCORE_URL: browse.nypl.org
-        VEGA_AUTH_DOMAIN: auth.na2.iiivega.com
-        CAS_SERVER_DOMAIN: ilsstaff.nypl.org
-        REDIRECT_SERVICE_DOMAIN: redir-browse.nypl.org
+        ENCORE_URL: qa-redir-browse.nypl.org
+        CAS_SERVER_DOMAIN: nypl-sierra-test.nypl.org
+        REDIRECT_SERVICE_DOMAIN: qa-redir-browse.nypl.org
         # SKIP_VEGA_LOGOUT: true
 Resources:
   RedirectService:

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -526,7 +526,7 @@ describe('handler', () => {
       const resp = await handler(baseEvent, context, (_, resp) => resp);
       const url = jsConditionalRedirect
         + '?redirect_uri=' + encodeURIComponent(
-          'https://auth.na2.iiivega.com/logout'
+          'https://nypl.na2.iiivega.com/logout'
             + '?redirect_uri='
             + encodeURIComponent(
               'https://redir-browse.nypl.org/vega-logout-handler?redirect_uri='
@@ -551,7 +551,7 @@ describe('handler', () => {
       'https://legacycatalog.nypl.org/',
       'https://nypl.na2.iiivega.com/',
       'https://www.nypl.org/research/research-catalog',
-      'https://auth.na2.iiivega.com/auth/realms/nypl/protocol/openid-connect/logout?redirect_uri=https://www.nypl.org/research/research-catalog/bib/b11373666'
+      'https://nypl.na2.iiivega.com/logout?redirect_uri=https://www.nypl.org/research/research-catalog/bib/b11373666'
     ].forEach((validUrl) => {
       it(`should respect redirect_uri=${validUrl}`, async function () {
         const eventWithRedirect = Object.assign( {}, baseEvent,
@@ -560,7 +560,7 @@ describe('handler', () => {
         const resp = await handler(eventWithRedirect, context, (_, resp) => resp);
         const url = jsConditionalRedirect
           + '?redirect_uri=' + encodeURIComponent(
-            'https://auth.na2.iiivega.com/logout?redirect_uri=' + encodeURIComponent(
+            'https://nypl.na2.iiivega.com/logout?redirect_uri=' + encodeURIComponent(
                'https://redir-browse.nypl.org/vega-logout-handler?redirect_uri=' + encodeURIComponent(validUrl)
             )
           )
@@ -588,7 +588,7 @@ describe('handler', () => {
         const resp = await handler(eventWithRedirect, context, (_, resp) => resp);
 
         const url = jsConditionalRedirect
-         + '?redirect_uri=' + encodeURIComponent('https://auth.na2.iiivega.com/logout?redirect_uri=https%3A%2F%2Fredir-browse.nypl.org%2Fvega-logout-handler%3Fredirect_uri%3D' + encodeURIComponent(encodeURIComponent('https://www.nypl.org/')))
+         + '?redirect_uri=' + encodeURIComponent('https://nypl.na2.iiivega.com/logout?redirect_uri=https%3A%2F%2Fredir-browse.nypl.org%2Fvega-logout-handler%3Fredirect_uri%3D' + encodeURIComponent(encodeURIComponent('https://www.nypl.org/')))
          + '&noscript_redirect_uri=https%3A%2F%2Filsstaff.nypl.org%2Fiii%2Fcas%2Flogout%3Fservice%3Dhttps%253A%252F%252Fwww.nypl.org%252F'
         expect(resp).to.deep.include({
           statusCode: 302,
@@ -603,7 +603,7 @@ describe('handler', () => {
       )
       const resp = await handler(eventWithRedirect, context, (_, resp) => resp);
       const url = jsConditionalRedirect
-        + '?redirect_uri=' + encodeURIComponent('https://auth.na2.iiivega.com/logout?redirect_uri=https%3A%2F%2Fredir-browse.nypl.org%2Fvega-logout-handler%3Fredirect_uri%3D' + encodeURIComponent(encodeURIComponent('https://nypl.na2.iiivega.com/')))
+        + '?redirect_uri=' + encodeURIComponent('https://nypl.na2.iiivega.com/logout?redirect_uri=https%3A%2F%2Fredir-browse.nypl.org%2Fvega-logout-handler%3Fredirect_uri%3D' + encodeURIComponent(encodeURIComponent('https://nypl.na2.iiivega.com/')))
         + '&noscript_redirect_uri=https%3A%2F%2Filsstaff.nypl.org%2Fiii%2Fcas%2Flogout%3Fservice%3Dhttps%253A%252F%252Fnypl.na2.iiivega.com%252F'
       expect(resp).to.deep.include({
         statusCode: 302,

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -38,6 +38,11 @@ describe('utils', function () {
       expect(utils.getRedirectUri({ custom_param: ['https://www.nypl.org/'] }, 'custom_param'))
             .to.eq('https://www.nypl.org/')
     })
+
+    it('decodes encoded redirect_uri value', () => {
+      expect(utils.getRedirectUri({ redirect_uri: [encodeURIComponent('https://www.nypl.org/')] }))
+            .to.eq('https://www.nypl.org/')
+    })
   })
 })
  

--- a/utils.js
+++ b/utils.js
@@ -86,7 +86,7 @@ function getRedirectUri (query, param = 'redirect_uri') {
   let redirectUri = Array.isArray(query[param]) ? query[param][0] : null
   if (redirectUri) redirectUri = redirectUri.replace(/(www\.)?discovery\.nypl\.org/, 'www.nypl.org')
   // Query string values arrive decoded through sam; They are not decoded when
-  // when arriving via ELB integration (i.e. deployed). So attempt to detect:
+  // arriving via ELB integration (i.e. deployed). So attempt to detect:
   if (redirectUri && /^https?%3A/.test(redirectUri)) redirectUri = decodeURIComponent(redirectUri)
   return validRedirectUrl(redirectUri)
     ? redirectUri

--- a/utils.js
+++ b/utils.js
@@ -85,6 +85,9 @@ function validRedirectUrl (url) {
 function getRedirectUri (query, param = 'redirect_uri') {
   let redirectUri = Array.isArray(query[param]) ? query[param][0] : null
   if (redirectUri) redirectUri = redirectUri.replace(/(www\.)?discovery\.nypl\.org/, 'www.nypl.org')
+  // Query string values arrive decoded through sam; They are not decoded when
+  // when arriving via ELB integration (i.e. deployed). So attempt to detect:
+  if (redirectUri && /^https?%3A/.test(redirectUri)) redirectUri = decodeURIComponent(redirectUri)
   return validRedirectUrl(redirectUri)
     ? redirectUri
     : `https://${VEGA_URL}/`


### PR DESCRIPTION
Fixes a few issues discovered when testing the reincorporated Vega logout:
 - Use `nypl.na2` domain instead of `auth.na2`
 - Use `multiValueHeaders` instead of `headers` since only former is honored by Load Balancer integration
