### PR TITLE
Fix broken header reading

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,8 +83,9 @@ const jsConditionalRedirect = (jsRedirect, noscriptRedirect) => {
 }
 
 const handler = async (event, context, callback) => {
-  const headers = event.headers || {}
-  const proto = headers['X-Forwarded-Proto'] || headers['x-forwarded-proto'] || 'https'
+  const headers = event.multiValueHeaders || {}
+  const proto = headers['X-Forwarded-Proto'] ? headers['X-Forwarded-Proto'][0] :
+    ( headers['x-forwarded-proto'] ? headers['x-forwarded-proto'][0] : 'https')
   try {
     const path = event.path;
     if (path === '/check') return callback(null, healthCheck());
@@ -99,7 +100,8 @@ const handler = async (event, context, callback) => {
       }
     }
 
-    const host = headers.host || ENCORE_URL;
+    const host = headers['Host'] ? headers['Host'][0] :
+      (headers['host'] ? headers['host'][0] : ENCORE_URL);
     const mappedUrl = mapToRedirectURL(path, query, host, proto);
     const redirectLocation = `${proto}://${mappedUrl}`;
 
@@ -123,8 +125,7 @@ const handler = async (event, context, callback) => {
   }
   catch (err) {
     console.log('err: ', err.message);
-    let mappedUrl = BASE_SCC_URL;
-    let redirectLocation = `${proto}://${mappedUrl}`;
+    let mappedUrl = BASE_SCC_URL; let redirectLocation = `${proto}://${mappedUrl}`;
     const response = {
       isBase64Encoded: false,
       statusCode: 302,

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -23,6 +23,11 @@ Resources:
       Handler: index.handler
       Runtime: nodejs12.x
       Events:
+        RedirectServiceRoot:
+          Type: Api
+          Properties:
+            Path: /
+            Method: any
         RedirectServiceCatchAll:
           Type: Api
           Properties:

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -442,9 +442,9 @@ describe('handler', () => {
     // fall through to a 404 page:
     const event = {
       path: '/record=bsomeid/',
-      headers: {
-        'x-forwarded-proto': 'https',
-        host: 'catalog.nypl.org'
+      multiValueHeaders: {
+        'x-forwarded-proto': ['https'],
+        host: ['catalog.nypl.org']
       }
     }
 
@@ -459,9 +459,9 @@ describe('handler', () => {
     it('should redirect to vega with converted bib id when "circ" set as collection query param', async function () {
       const event = {
         path: '/record=b22297361',
-        headers: {
-          'x-forwarded-proto': 'https',
-          host: 'catalog.nypl.org'
+        multiValueHeaders: {
+          'x-forwarded-proto': ['https'],
+          host: ['catalog.nypl.org']
         },
         multiValueQueryStringParameters: {
           "collection": ["circ"]
@@ -477,9 +477,9 @@ describe('handler', () => {
     it('should redirect to vega when "circ" is included in multiple collection query params', async function () {
       const event = {
         path: '/record=b22297361',
-        headers: {
-          'x-forwarded-proto': 'https',
-          host: 'catalog.nypl.org'
+        multiValueHeaders: {
+          'x-forwarded-proto': ['https'],
+          host: ['catalog.nypl.org']
         },
         multiValueQueryStringParameters: {
           "collection": ["circ", "research"]
@@ -495,9 +495,9 @@ describe('handler', () => {
     it('should redirect to research catalog when anything other than "circ" is in collection query params', async function () {
       const event = {
         path: '/record=b22297361',
-        headers: {
-          'x-forwarded-proto': 'https',
-          host: 'catalog.nypl.org'
+        multiValueHeaders: {
+          'x-forwarded-proto': ['https'],
+          host: ['catalog.nypl.org']
         },
         multiValueQueryStringParameters: {
           "collection": ["research"]
@@ -516,9 +516,9 @@ describe('handler', () => {
 
     const baseEvent = {
       path: '/iii/encore/logoutFilterRedirect',
-      headers: {
-        'x-forwarded-proto': 'https',
-        host: 'browse.nypl.org'
+      multiValueHeaders: {
+        'x-forwarded-proto': ['https'],
+        host: ['browse.nypl.org']
       }
     }
 
@@ -615,9 +615,9 @@ describe('handler', () => {
   describe('vega logout handler', function () {
     const baseEvent = {
       path: '/vega-logout-handler',
-      headers: {
-        'x-forwarded-proto': 'https',
-        host: 'redir-browse.nypl.org'
+      multiValueHeaders: {
+        'x-forwarded-proto': ['https'],
+        host: ['redir-browse.nypl.org']
       }
     }
     it('should send user through CAS, passing valid redirect', async function () {


### PR DESCRIPTION
AWS sam cli presents headers via both a `headers` and a `multiValueHeaders` property on the event. But deployed code only sees `multiValueHeaders`.