### PR TITLE
Configure qa&prod to use new Vega dns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,7 @@ deploy:
    - ENCORE_URL=qa-redir-browse.nypl.org
    - LEGACY_CATALOG_URL=nypl-sierra-test.nypl.org
    - REDIRECT_SERVICE_DOMAIN=qa-redir-browse.nypl.org
-   # Temporarily point to Vega Train to test Vega DNS update:
-   # - VEGA_URL=nypl.na2.iiivega.com
-   - VEGA_URL=nypl-vega-train.nypl.org
+   - VEGA_URL=borrow.nypl.org
   on:
     branch: qa
 - provider: lambda
@@ -53,7 +51,7 @@ deploy:
    - ENCORE_URL=browse.nypl.org
    - LEGACY_CATALOG_URL=legacycatalog.nypl.org
    - REDIRECT_SERVICE_DOMAIN=redir-browse.nypl.org
-   - VEGA_URL=nypl.na2.iiivega.com
+   - VEGA_URL=borrow.nypl.org
   on:
     branch: production
 after_deploy:

--- a/test/unit/test-helper.js
+++ b/test/unit/test-helper.js
@@ -3,7 +3,7 @@ const loadTestEnvironment = () => {
   process.env.BASE_SCC_URL = 'www.nypl.org/research/research-catalog'
   process.env.LEGACY_CATALOG_URL = 'legacycatalog.nypl.org'
   process.env.ENCORE_URL = 'browse.nypl.org'
-  process.env.VEGA_URL = 'nypl.na2.iiivega.com'
+  process.env.VEGA_URL = 'borrow.nypl.org'
   process.env.CAS_SERVER_DOMAIN = 'ilsstaff.nypl.org'
   process.env.REDIRECT_SERVICE_DOMAIN = 'redir-browse.nypl.org'
 }

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -4,6 +4,16 @@ require('./test-helper').loadTestEnvironment()
 
 const utils = require('../../utils')
 
+const {
+  mapToRedirectURL,
+  handler,
+  reconstructOriginalURL,
+  ENCORE_URL,
+  BASE_SCC_URL,
+  VEGA_URL,
+  LEGACY_CATALOG_URL
+} = require('../../index.js');
+
 describe('utils', function () {
   describe('validRedirectUrl', () => {
     it('should mark unknown domains/base URLs as not valid', function () {
@@ -11,14 +21,14 @@ describe('utils', function () {
       expect(utils.validRedirectUrl('https://duckduckgo.com?q=https://catalog.nypl.org')).to.eq(false)
       expect(utils.validRedirectUrl('https://www.nypl.org.us')).to.eq(false)
       // Require a trailing slash:
-      expect(utils.validRedirectUrl('https://nypl.na2.iiivega.com')).to.eq(false)
+      expect(utils.validRedirectUrl(`https://${VEGA_URL}`)).to.eq(false)
     })
 
     it('should mark known domains as valid', function () {
       expect(utils.validRedirectUrl('https://www.nypl.org/')).to.eq(true)
       expect(utils.validRedirectUrl('https://legacycatalog.nypl.org/')).to.eq(true)
       expect(utils.validRedirectUrl('https://www.nypl.org/research/research-catalog')).to.eq(true)
-      expect(utils.validRedirectUrl('https://nypl.na2.iiivega.com/')).to.eq(true)
+      expect(utils.validRedirectUrl(`https://${VEGA_URL}/`)).to.eq(true)
     })
   })
 


### PR DESCRIPTION
Update VEGA_URL in `.travis.yml` to use borrow.nypl.org in qa and prod

Updates tests accordingly.

Part 2 of https://jira.nypl.org/browse/SCC-3795

May not be merged until DNS has been set up to point borrow.nypl.org to Vega