### PR TITLE
Noref allow all nypl redirect uris

### DIFF
--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -22,7 +22,7 @@ describe('utils', function () {
       expect(utils.validRedirectUrl('https://www.nypl.org.us')).to.eq(false)
       // Require a trailing slash:
       expect(utils.validRedirectUrl(`https://${VEGA_URL}`)).to.eq(false)
-      // Require https:
+      // Require https on nypl.org (allow http: on local.nypl.org only):
       expect(utils.validRedirectUrl('http://www.nypl.org/')).to.eq(false)
     })
 
@@ -33,7 +33,7 @@ describe('utils', function () {
       expect(utils.validRedirectUrl('https://qa-research-catalog.nypl.org/research/research-catalog')).to.eq(true)
       expect(utils.validRedirectUrl(`https://${VEGA_URL}/`)).to.eq(true)
 
-      // Also local domains:
+      // Also local domains over http:
       expect(utils.validRedirectUrl('http://local.nypl.org:8080/')).to.eq(true)
       expect(utils.validRedirectUrl('http://local.nypl.org:3001/')).to.eq(true)
       expect(utils.validRedirectUrl('http://local.nypl.org:1234/')).to.eq(true)

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -22,6 +22,8 @@ describe('utils', function () {
       expect(utils.validRedirectUrl('https://www.nypl.org.us')).to.eq(false)
       // Require a trailing slash:
       expect(utils.validRedirectUrl(`https://${VEGA_URL}`)).to.eq(false)
+      // Require https:
+      expect(utils.validRedirectUrl('http://www.nypl.org/')).to.eq(false)
     })
 
     it('should mark known domains as valid', function () {

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -28,6 +28,7 @@ describe('utils', function () {
       expect(utils.validRedirectUrl('https://www.nypl.org/')).to.eq(true)
       expect(utils.validRedirectUrl('https://legacycatalog.nypl.org/')).to.eq(true)
       expect(utils.validRedirectUrl('https://www.nypl.org/research/research-catalog')).to.eq(true)
+      expect(utils.validRedirectUrl('https://qa-research-catalog.nypl.org/research/research-catalog')).to.eq(true)
       expect(utils.validRedirectUrl(`https://${VEGA_URL}/`)).to.eq(true)
 
       // Also local domains:

--- a/utils.js
+++ b/utils.js
@@ -66,12 +66,13 @@ const getQueryFromParams = (url, query) => {
 const recodeSearchQuery = query => query.split(/\+|\s/).join("%20");
 
 /**
- *  Given a URL, returns true if the URL we should redirect there (i.e. is a
- *  known catalog URL)
+ *  Given a URL, returns true if we should redirect there (i.e. it's a domain
+ *  that we control or a local testing domain)
  */
 function validRedirectUrl (url) {
   if (!url) return false
 
+  // It's valid if it matches https://*.nypl.org or http://local.nypl.org:PORT:
   return /^(https:\/\/[\w-]+\.nypl.org\/|http:\/\/local.nypl.org:\d+\/)/.test(url)
 }
 

--- a/utils.js
+++ b/utils.js
@@ -72,12 +72,7 @@ const recodeSearchQuery = query => query.split(/\+|\s/).join("%20");
 function validRedirectUrl (url) {
   if (!url) return false
 
-  const wwwDomain = BASE_SCC_URL.split('/')[0]
-  return [wwwDomain, ENCORE_URL, LEGACY_CATALOG_URL, VEGA_URL, CAS_SERVER_DOMAIN]
-    .map((domain) => `https://${domain}/`)
-    .some((baseUrl) => url.indexOf(baseUrl) === 0)
-    // Also allow dev domains:
-    || /^http:\/\/local.nypl.org:\d+\//.test(url)
+  return /^(https:\/\/[\w-]+\.nypl.org\/|http:\/\/local.nypl.org:\d+\/)/.test(url)
 }
 
 /**


### PR DESCRIPTION
Simplified `redirect_uri` validation to match any *.nypl.org domain (including local domains). Previously we were explicitly matching against a list of known hosts, but all of the allowed hosts are *.nypl.org now.