### PR TITLE
Add logic for mapping oclc to bib id for circulating records

### DIFF
--- a/expressions.js
+++ b/expressions.js
@@ -94,11 +94,19 @@ module.exports = {
       // check if bib is research or circulating
       const oclcNum = match[1]
       const client = await nyplApiClient({ apiName: 'discovery' })
-      const resp = await client.get(`/discovery/resources?q=${oclcNum}&search_scope=standard_number&per_page=1}`)
-      if (resp.totalResults > 0) {
+      const resp = await client.get(`bibs?nyplSource=sierra-nypl&controlNumber=${oclcNum}`)
+      const id = resp && resp.data && resp.data[0] && resp.data[0].id
+      const varFields = resp && resp.data && resp.data[0] && resp.data[0].varFields
+      const field910a = varFields && varFields.find(field =>
+        field.marcTag === '910'
+        && field.subfields.some(subfield => subfield.tag === 'a')
+      )
+      const isResearch = field910a && field910a.subfields.some(subfield => subfield.tag === 'a' && subfield.content === 'RL')
+
+      if (isResearch) {
         return `${BASE_SCC_URL}/search?oclc=${oclcNum}&redirectOnMatch=true`
       } else {
-        return `${VEGA_URL}/search/card?recordId=${oclcNum}`
+        return `${VEGA_URL}/search/card?recordId=${id}`
       }
     },
   },

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -155,7 +155,22 @@ describe('mapToRedirectURL', function () {
       before(() => {
         sinon.stub(NyplApiClient.prototype, 'get').callsFake(() => {
           return {
-            totalResults: 1
+            data: [
+              {
+                id: 'abcdefg',
+                varFields: [
+                  {
+                    marcTag: '910',
+                    subfields: [
+                      {
+                        tag: 'a',
+                        content: 'RL'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         })
 
@@ -183,7 +198,22 @@ describe('mapToRedirectURL', function () {
       before(() => {
         sinon.stub(NyplApiClient.prototype, 'get').callsFake(() => {
           return {
-            totalResults: 0
+            data: [
+              {
+                id: 'abcdefg',
+                varFields: [
+                  {
+                    marcTag: '910',
+                    subfields: [
+                      {
+                        tag: 'a',
+                        content: 'BL'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         })
 
@@ -203,7 +233,7 @@ describe('mapToRedirectURL', function () {
         const path = '/search/o1081334684';
         const mapped = await mapToRedirectURL(path, {}, host, method);
         expect(mapped)
-        .to.include(`${VEGA_URL}/search/card?recordId=1081334684`);
+        .to.include(`${VEGA_URL}/search/card?recordId=abcdefg`);
       });
     })
 
@@ -211,7 +241,22 @@ describe('mapToRedirectURL', function () {
       before(() => {
         sinon.stub(NyplApiClient.prototype, 'get').callsFake(() => {
           return {
-            totalResults: 1
+            data: [
+              {
+                id: 'abcdefg',
+                varFields: [
+                  {
+                    marcTag: '910',
+                    subfields: [
+                      {
+                        tag: 'a',
+                        content: 'RL'
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         })
       })


### PR DESCRIPTION
This branch deals with redirecting bib searches based on oclc number.
In case we find a bib that needs to be redirected to Vega, we need to fetch its id.

This change modifies the logic for determining if a bib fetched by oclc number needs to be redirected to RC or Vega to do the following:
- Request the bib from the Bib service based on control number
- Check the 910a field to determine if it is research
- If redirecting to Vega, extract the id from the record.

In addition, there are some modified tests.