### PR TITLE
Scc 4842

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,6 @@ require('dotenv').config({ path: `./config/${process.env.ENVIRONMENT}.env` })
 // the path, and returns the corresponding handler with the matchdata and query
 // As a default, returns the BASE_SCC_URL
 async function mapToRedirectURL (path, query, host, proto) {
-  console.log('path: ', path)
-  console.log('query: ', query)
-  console.log('host: ', host)
-  console.log('proto: ', proto)
   const redirectingFromEncore = host === ENCORE_URL
   const redirectingFromLegacyOrVegaToSCC = !redirectingFromEncore && host !== REDIRECT_SERVICE_DOMAIN
   let redirectURL;

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ require('dotenv').config({ path: `./config/${process.env.ENVIRONMENT}.env` })
 // the path, and returns the corresponding handler with the matchdata and query
 // As a default, returns the BASE_SCC_URL
 async function mapToRedirectURL (path, query, host, proto) {
+  console.log('path: ', path)
+  console.log('query: ', query)
+  console.log('host: ', host)
+  console.log('proto: ', proto)
   const redirectingFromEncore = host === ENCORE_URL
   const redirectingFromLegacyOrVegaToSCC = !redirectingFromEncore && host !== REDIRECT_SERVICE_DOMAIN
   let redirectURL;

--- a/sam.local.yml
+++ b/sam.local.yml
@@ -22,7 +22,7 @@ Resources:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs20.x
       Events:
         RedirectServiceRoot:
           Type: Api

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -151,6 +151,14 @@ describe('mapToRedirectURL', function () {
         .to.eql(`${BASE_SCC_URL}/search?q=brainwash&search_scope=title&originalUrl=https%3A%2F%2Fcatalog.nypl.org%2Fsearch~S97%3F%2Ftbrainwash%2Ftbrainwash%2F1%2C3%2C10%2CB%2Fexact%26FF%3Dtbrainwash%261%2C4%2C`)
     });
 
+    it('should map search pages with index c to callnumber', async function () {
+      const path = '/search~S1';
+      const query = { '/c*pwz/c*pwz/1,9837,17665,E/limit': [ '' ] };
+      const mapped = await mapToRedirectURL(path, query, host, method);
+      expect(mapped)
+        .to.include(`${BASE_SCC_URL}/search?q=*pwz&search_scope=callnumber`)
+    });
+
     describe('mapping oclc records in the research catalog', async () => {
       before(() => {
         sinon.stub(NyplApiClient.prototype, 'get').callsFake(() => {

--- a/utils.js
+++ b/utils.js
@@ -17,7 +17,7 @@ const indexMappings = {
   // h: '', // there is no genre search
   // d: '', // this is the subject search, might want to do something different
   i: '&search_scope=standard_number', // what to do with these?
-  c: '&search_scope=standard_number',
+  c: '&search_scope=callnumber',
 }
 const homeHandler = (match, query, host) => {
   // If host is catalog.nypl.org (or qa-catalog.nypl.org), redirect to RC (else Vega)


### PR DESCRIPTION
- Changes the index mapping so `c` maps to `callnumber` e.g. https://catalog.nypl.org/search~S1?/c*pwz/c*pwz/1%2C9837%2C17665%2CE/limit should redirect to  https://www.nypl.org/research/research-catalog/search?q=*pwz&search_scope=callnumber (+ the origUrl param), as described in [SCC-4841](https://newyorkpubliclibrary.atlassian.net/browse/SCC-4842)
- Adds a test
- Unrelated: bump the node version in sam since 12 is no longer supported