### PR TITLE
Add nypl-sierra-train as deprecated host

### DIFF
--- a/config/qa.env
+++ b/config/qa.env
@@ -1,6 +1,6 @@
 # Hosts this app listens on:
 DEPRECATED_ENCORE_HOSTS=nypl-encore-test.nypl.org
-DEPRECATED_WEBPAC_HOSTS=qa-catalog.nypl.org,qa-legacycatalog.nypl.org,nypl-sierra-test.nypl.org
+DEPRECATED_WEBPAC_HOSTS=qa-catalog.nypl.org,qa-legacycatalog.nypl.org,nypl-sierra-test.nypl.org,nypl-sierra-train.nypl.org
 DEPRECATED_DISCOVERY_HOST=qa-discovery.nypl.org
 REDIRECT_SERVICE_HOST=qa-redir-browse.nypl.org
 


### PR DESCRIPTION
To test RedirectService handling traffic for nypl-sierra-train.nypl.org when we test directing DNS there.